### PR TITLE
Upgrade to SimpleSAMLphp 2.0.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM rockylinux/rockylinux:8.4 as download_ssp
+FROM rockylinux/rockylinux:9 as download_ssp
 
-ARG SIMPLE_SAML_PHP_VERSION=1.19.6
-ARG SIMPLE_SAML_PHP_HASH=834bb4a89d63d7498e77cceb49e01b919d1c0a6a3d38a992f905810dad424b7c
+ARG SIMPLE_SAML_PHP_VERSION=2.0.2
+ARG SIMPLE_SAML_PHP_HASH=ce974d387eba6e37dc502bd7fa7a5c7803f9572c59ac9c05cbc03b5fc0220838
 
 RUN dnf install -y wget \
     && ssp_version=$SIMPLE_SAML_PHP_VERSION; \
@@ -12,22 +12,22 @@ RUN dnf install -y wget \
     && tar xzf /simplesamlphp-$ssp_version.tar.gz \
     && mv simplesamlphp-$ssp_version simplesamlphp
 
-FROM rockylinux/rockylinux:8.4
+FROM rockylinux/rockylinux:9
 
 LABEL maintainer="Unicon, Inc."
 
-ARG PHP_VERSION=7.4.19
-ARG HTTPD_VERSION=2.4.37
+ARG PHP_VERSION=8.1.8
+ARG HTTPD_VERSION=2.4.53
 
 COPY --from=download_ssp /var/simplesamlphp /var/simplesamlphp
 
-RUN dnf module enable -y php:7.4 \
+RUN dnf module enable -y php:8.1 \
     && dnf install -y httpd-$HTTPD_VERSION php-$PHP_VERSION \
     && dnf clean all \
     && rm -rf /var/cache/yum
 
-RUN echo $'\nSetEnv SIMPLESAMLPHP_CONFIG_DIR /var/simplesamlphp/config\nAlias /simplesaml /var/simplesamlphp/www\n \
-<Directory /var/simplesamlphp/www>\n \
+RUN echo $'\nSetEnv SIMPLESAMLPHP_CONFIG_DIR /var/simplesamlphp/config\nAlias /simplesaml /var/simplesamlphp/public\n \
+<Directory /var/simplesamlphp/public>\n \
     Require all granted\n \
 </Directory>\n' \
        >> /etc/httpd/conf/httpd.conf


### PR DESCRIPTION
* New SimpleSAMLphp version
* Bumped to Rocky Linux 9 with no minor version tag
* Also bumped to PHP 8.1.8 and HTTPD 2.4.53
* New SimpleSAMLphp comes with fewer modules To install modules, composer must be installed from the composer website. Additionally, php-intl and php-zip must be installed using dnf